### PR TITLE
allow user defined item.labels in ItemClassic

### DIFF
--- a/R/itemClassic.R
+++ b/R/itemClassic.R
@@ -1,5 +1,5 @@
 itemClassic <-
-function(thr, yRange = NULL, axis.items = "Items",axis.logits = "Logits",show.axis.logits = "R",oma = c(0,0,0,3),cutpoints = NULL,...) {
+function(thr, yRange = NULL, axis.items = "Items",axis.logits = "Logits",show.axis.logits = "R",oma = c(0,0,0,3),cutpoints = NULL, item.names.labels=FALSE, ...) {
 	Nbins <- function(thr,itemRange) {
 		
 		#print(paste("thr =", c(min(thr),max(thr))))
@@ -66,8 +66,14 @@ function(thr, yRange = NULL, axis.items = "Items",axis.logits = "Logits",show.ax
 	item.hist <- data.frame(xleft = item.hist$mids - (bin.size/2), ybottom = item.hist$mids * 0, xright = item.hist$mids + 
 		(bin.size/2), ytop = item.hist$counts)
 
-	item.labels <- matrix(rep(formatC(1:nI, digits = 1, format = "d", flag = "0"), nL), ncol = nL)
-	if(nL > 1){
+	# item.labels - use generic list or user defined item names 
+	if (item.names.labels==FALSE){
+	        item.labels <- matrix(rep(formatC(1:nI, digits = 1, format = "d", flag = "0"), nL), ncol = nL)
+	}else if(item.names.labels==TRUE){
+		item.labels<-matrix(row.names(thr))
+	}
+		
+        if(nL > 1){
 		item.labels <- t(apply(item.labels, 1, paste, c(1:nL), sep = "."))
 	}
 	

--- a/R/wrightMap.R
+++ b/R/wrightMap.R
@@ -1,5 +1,5 @@
 wrightMap <-
-function(thetas, thresholds = NULL, item.side = itemModern, person.side = personHist,  main.title = "Wright Map", min.logit.pad = 0.25, max.logit.pad = 0.25, min.l = NULL, max.l = NULL, item.prop = 0.8, return.thresholds = TRUE, new.quartz = FALSE, use.hist = NULL,...) {
+function(thetas, thresholds = NULL, item.side = itemModern, person.side = personHist,  main.title = "Wright Map", min.logit.pad = 0.25, max.logit.pad = 0.25, min.l = NULL, max.l = NULL, item.prop = 0.8, return.thresholds = TRUE, new.quartz = FALSE, use.hist = NULL, item.names.labels=FALSE, ...) {
 
 	## Helper Functions
 
@@ -53,7 +53,7 @@ function(thetas, thresholds = NULL, item.side = itemModern, person.side = person
 	item.screen <- screen()
 	dots <- list(...)
 	dots[c("yRange","oma")] <- NULL
-	item.params <- list(thr = thresholds,yRange = yRange,oma = c(0,0,0,0))
+	item.params <- list(thr = thresholds,yRange = yRange,oma = c(0,0,0,0), item.names.labels=item.names.labels)
 	do.call(item.side,c(item.params,dots))
 	par(oma = c(0, 0, 3, 0))
 	mtext(main.title, side = 3, line = 1, outer = TRUE, font = 2)


### PR DESCRIPTION
identified in #6 
now we can use  item.names.labels=TRUE  or item.names.labels=FALSE to decide which labels to use

eg
`WrightMap::WrightMap(PersonAbility, Thresholds, 
                         mainTitle = "Wright Map", 
                         item.side = itemClassic , 
                         show.thr.lab = TRUE, 
                         show.thr.sym = FALSE, 
                         width = 2, 
                         height = 2, 
                         dim.color = WrightColour(test),
                         item.names.labels=TRUE)  `